### PR TITLE
Make diff filter properly single-line hunk headers.

### DIFF
--- a/coverage_reporter/filters/patch.py
+++ b/coverage_reporter/filters/patch.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 
 from coverage_reporter.plugins import Plugin, Option
 
@@ -50,9 +51,9 @@ def _get_lines_from_patch(patch_file, patch_level):
         elif line.startswith('@@'):
             # @@ -old_lineno,old_end +new_lineno,new_end @@ <extra info>
             # place marker - we want to start counting lines at new_lineno
-            line = line[line.find('+')+1:]
-            line = line[:line.find(',')]
-            cur_line = int(line)
+            m = re.match(r'@@ -[0-9]+(?:,[0-9]+)? \+([0-9]+)(?:,[0-9]+)? @@', line)
+            if m:
+                cur_line = int(m.groups()[0])
         elif line.startswith('+'):
             # added line
             file_dict[new_file].append(cur_line)

--- a/tests/data/oneline.file
+++ b/tests/data/oneline.file
@@ -1,0 +1,1 @@
+I have one line.

--- a/tests/data/oneline.patch
+++ b/tests/data/oneline.patch
@@ -1,0 +1,6 @@
+diff --git a/tests/data/oneline.file b/tests/data/oneline.file
+index e69de29..b23680e 100644
+--- a/tests/data/oneline.file
++++ b/tests/data/oneline.file
+@@ -0,0 +1 @@
++I have one line.

--- a/tests/test_filters/test_patch.py
+++ b/tests/test_filters/test_patch.py
@@ -12,3 +12,13 @@ class PathTest(CoverageReporterTestCase):
         path = new_data.canonical_path('tests/data/prog3.py')
         self.assertEqual(new_data.lines[path], set([1,6,8]))
         self.assertEqual(new_data.covered[path], set([1,2,3,6,8]))
+
+    def test_patch_filter_oneline(self):
+        data = self.create_exact_coverage_data({'tests/data/oneline.file' : {'lines': [1], 'covered': [1]}})
+        filter = self.load_plugin('patch')
+        filter.patch = 'tests/data/oneline.patch'
+        filter.patch_level = 1
+        new_data = filter.filter(data)
+        path = new_data.canonical_path('tests/data/oneline.file')
+        self.assertEqual(new_data.lines[path], set([1]))
+        self.assertEqual(new_data.covered[path], set([1]))


### PR DESCRIPTION
At least `git diff` generates a hunk header that looks like
`@@ -0,0 +1 @@` when the resulting file has a single line.
This makes `FilterByPatch` properly handle that.
